### PR TITLE
Fix carousel styles

### DIFF
--- a/src/containers/Carousel/_Carousel.scss
+++ b/src/containers/Carousel/_Carousel.scss
@@ -2,10 +2,8 @@
 
 .carousel-container {
   margin: 0 auto;
-  // border: 1px solid blue;
   width: 99%;
   h1 {
-    // border: 1px solid red;
     align-self: flex-start;
     padding: 1rem 0 0 0;
     color: $text-w;
@@ -15,11 +13,9 @@
 
 .carousel {
   display: flex;
-  justify-content: center;
-  flex-direction: column;
-  align-items: center;
+  min-width: 100%;
+  overflow-x: auto;
   margin: 1rem 0;
-  overflow: scroll;
 }
 
 .left::-webkit-scrollbar {


### PR DESCRIPTION
The carousel now starts at the first image rather than the center image.